### PR TITLE
Fix typo: 'textn' to 'text'

### DIFF
--- a/schema.md
+++ b/schema.md
@@ -50,7 +50,7 @@ Displays a list of items, such as work experience, projects, publications, etc.
 
 #### 2. **Text Section**
 
-Displays a block of plain textn.
+Displays a block of plain text.
 
 ```json
 {


### PR DESCRIPTION
### Summary

This pull request fixes a small typo in the documentation/component:
Changed `textn` to `text.`.

### Details

The typo was in schema.md. It likely happened due to a stray `n` at the end.

Let me know if you'd like any other changes. 🙂